### PR TITLE
Add Pod Labels to DCGM Exporter Metrics

### DIFF
--- a/pkg/cmd/app.go
+++ b/pkg/cmd/app.go
@@ -55,6 +55,7 @@ const (
 	CLIAddress                    = "address"
 	CLICollectInterval            = "collect-interval"
 	CLIKubernetes                 = "kubernetes"
+	CLIKubernetesEnablePodLabels  = "kubernetes-enable-pod-labels"
 	CLIKubernetesGPUIDType        = "kubernetes-gpu-id-type"
 	CLIUseOldNamespace            = "use-old-namespace"
 	CLIRemoteHEInfo               = "remote-hostengine-info"
@@ -147,6 +148,12 @@ func NewApp(buildVersion ...string) *cli.App {
 			Value:   "localhost:5555",
 			Usage:   "Connect to remote hostengine at <HOST>:<PORT>",
 			EnvVars: []string{"DCGM_REMOTE_HOSTENGINE_INFO"},
+		},
+		&cli.BoolFlag{
+			Name:    CLIKubernetesEnablePodLabels,
+			Value:   false,
+			Usage:   "Enable kubernetes pod labels in metrics. This parameter is effective only when the '--kubernetes' option is set to 'true'.",
+			EnvVars: []string{"DCGM_EXPORTER_KUBERNETES_ENABLE_POD_LABELS"},
 		},
 		&cli.StringFlag{
 			Name:  CLIKubernetesGPUIDType,
@@ -617,6 +624,7 @@ func contextToConfig(c *cli.Context) (*dcgmexporter.Config, error) {
 		Address:                    c.String(CLIAddress),
 		CollectInterval:            c.Int(CLICollectInterval),
 		Kubernetes:                 c.Bool(CLIKubernetes),
+		KubernetesEnablePodLabels:  c.Bool(CLIKubernetesEnablePodLabels),
 		KubernetesGPUIdType:        dcgmexporter.KubernetesGPUIDType(c.String(CLIKubernetesGPUIDType)),
 		CollectDCP:                 true,
 		UseOldNamespace:            c.Bool(CLIUseOldNamespace),

--- a/pkg/dcgmexporter/config.go
+++ b/pkg/dcgmexporter/config.go
@@ -36,6 +36,7 @@ type Config struct {
 	Address                    string
 	CollectInterval            int
 	Kubernetes                 bool
+	KubernetesEnablePodLabels  bool
 	KubernetesGPUIdType        KubernetesGPUIDType
 	CollectDCP                 bool
 	UseOldNamespace            bool

--- a/pkg/dcgmexporter/kubernetes.go
+++ b/pkg/dcgmexporter/kubernetes.go
@@ -249,5 +249,12 @@ func (p *PodMapper) getPodLabels(namespace, podName string) (map[string]string, 
 		return nil, err
 	}
 
-	return pod.Labels, nil
+	// Sanitize label names
+	sanitizedLabels := make((map[string]string), len(pod.Labels))
+	for k, v := range pod.Labels {
+		sanitizedKey := SanitizeLabelName(k)
+		sanitizedLabels[sanitizedKey] = v
+	}
+
+	return sanitizedLabels, nil
 }

--- a/pkg/dcgmexporter/kubernetes.go
+++ b/pkg/dcgmexporter/kubernetes.go
@@ -246,7 +246,7 @@ func (p *PodMapper) getPodLabels(namespace, podName string) (map[string]string, 
 
 	pod, err := p.Client.CoreV1().Pods(namespace).Get(ctx, podName, metav1.GetOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("failed to fetch labels: %w", err)
+		return nil, err
 	}
 
 	return pod.Labels, nil

--- a/pkg/dcgmexporter/types.go
+++ b/pkg/dcgmexporter/types.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/NVIDIA/go-dcgm/pkg/dcgm"
 	"github.com/prometheus/exporter-toolkit/web"
+	"k8s.io/client-go/kubernetes"
 )
 
 var (
@@ -142,12 +143,14 @@ type MetricsServer struct {
 
 type PodMapper struct {
 	Config *Config
+	Client kubernetes.Interface
 }
 
 type PodInfo struct {
 	Name      string
 	Namespace string
 	Container string
+	Labels    map[string]string
 }
 
 // MetricsByCounter represents a map where each Counter is associated with a slice of Metric objects

--- a/pkg/dcgmexporter/utils.go
+++ b/pkg/dcgmexporter/utils.go
@@ -20,9 +20,12 @@ import (
 	"bytes"
 	"encoding/gob"
 	"fmt"
+	"regexp"
 	"sync"
 	"time"
 )
+
+var invalidLabelCharRE = regexp.MustCompile(`[^a-zA-Z0-9_]`)
 
 func WaitWithTimeout(wg *sync.WaitGroup, timeout time.Duration) error {
 	c := make(chan struct{})
@@ -62,4 +65,8 @@ func deepCopy[T any](src T) (dst T, err error) {
 	}
 
 	return dst, nil
+}
+
+func SanitizeLabelName(s string) string {
+	return invalidLabelCharRE.ReplaceAllString(s, "_")
 }

--- a/pkg/dcgmexporter/utils_test.go
+++ b/pkg/dcgmexporter/utils_test.go
@@ -60,3 +60,26 @@ func TestDeepCopy(t *testing.T) {
 		assert.Error(t, err)
 	})
 }
+
+func TestSanitizeLabelName(t *testing.T) {
+	t.Run("Sanitize label with invalid characters", func(t *testing.T) {
+		input := "label.with.dots/and-slashes"
+		expected := "label_with_dots_and_slashes"
+		got := SanitizeLabelName(input)
+		assert.Equal(t, expected, got)
+	})
+
+	t.Run("Sanitize label with special characters", func(t *testing.T) {
+		input := "label@with#special!chars"
+		expected := "label_with_special_chars"
+		got := SanitizeLabelName(input)
+		assert.Equal(t, expected, got)
+	})
+
+	t.Run("Keep valid label unchanged", func(t *testing.T) {
+		input := "valid_label_name"
+		expected := "valid_label_name"
+		got := SanitizeLabelName(input)
+		assert.Equal(t, expected, got)
+	})
+}

--- a/tests/e2e/e2e_suite_test.go
+++ b/tests/e2e/e2e_suite_test.go
@@ -293,4 +293,208 @@ var _ = Describe("dcgm-exporter-e2e-suite", func() {
 			}
 		})
 	})
+
+	When("DCGM exporter is deployed on kubernetes with pod labels collection enabled", Ordered, func() {
+		var (
+			kubeClient      *framework.KubeClient
+			helmClient      *framework.HelmClient
+			helmReleaseName string
+			dcgmExpPod      *corev1.Pod
+			workloadPod     *corev1.Pod
+			customLabels    = map[string]string{"custom-key": "custom-value", "another-key": "another-value"}
+			labelMap        = map[string]string{dcgmExporterPodNameLabel: dcgmExporterPodNameLabelValue}
+		)
+
+		BeforeAll(func(ctx context.Context) {
+			if testContext.kubeconfig == "" {
+				_, _ = fmt.Fprintln(GinkgoWriter, "kubeconfig parameter is empty. Defaulting to ~/.kube/config")
+			}
+
+			if len(testContext.chart) == 0 {
+				Fail("chart parameter is empty")
+			}
+
+			shouldResolvePath()
+			kubeConfigShouldExists()
+
+			k8sConfig := shouldCreateK8SConfig()
+			kubeClient = shouldCreateKubeClient(k8sConfig)
+			helmClient = shouldCreateHelmClient(k8sConfig)
+		})
+
+		AfterAll(func(ctx context.Context) {
+			_, _ = fmt.Fprintln(GinkgoWriter, "Starting cleanup for DCGM exporter with pod labels")
+
+			shouldUninstallHelmChart(helmClient, helmReleaseName)
+			shouldCleanupHelmClient(helmClient)
+			shouldDeleteNamespace(ctx, kubeClient)
+
+			_, _ = fmt.Fprintln(GinkgoWriter, "Cleanup completed")
+		})
+
+		It("should create namespace", func(ctx context.Context) {
+			shouldCreateNamespace(ctx, kubeClient, map[string]string{})
+		})
+
+		It("should install dcgm-exporter helm chart with pod labels enabled", func(ctx context.Context) {
+			_, _ = fmt.Fprintf(GinkgoWriter, "Helm chart installation: %q chart started.\n",
+				testContext.chart)
+
+			values := []string{
+				"serviceMonitor.enabled=false",
+				"extraEnvVars[0].name=DCGM_EXPORTER_ENABLE_POD_LABELS",
+				"extraEnvVars[0].value=true",
+			}
+
+			var err error
+			helmReleaseName, err = helmClient.Install(ctx, values, framework.HelmChartOptions{
+				CleanupOnFail: true,
+				GenerateName:  true,
+				Timeout:       5 * time.Minute,
+				Wait:          true,
+			})
+			Expect(err).ShouldNot(HaveOccurred(), "Failed to install DCGM exporter Helm chart")
+
+			_, _ = fmt.Fprintf(GinkgoWriter, "Helm chart installation: %q completed.\n",
+				testContext.chart)
+			_, _ = fmt.Fprintf(GinkgoWriter, "Helm chart installation: new %q release name.\n",
+				helmReleaseName)
+		})
+
+		It("should create dcgm-exporter pod", func(ctx context.Context) {
+			_, _ = fmt.Fprintln(GinkgoWriter, "Pod creation verification: started")
+
+			Eventually(func(ctx context.Context) bool {
+				pods, err := kubeClient.GetPodsByLabel(ctx, testContext.namespace, labelMap)
+				if err != nil {
+					Fail(fmt.Sprintf("Error retrieving DCGM exporter pod: %v", err))
+					return false
+				}
+				if len(pods) == 1 {
+					dcgmExpPod = &pods[0]
+					return true
+				}
+				return false
+			}).WithPolling(time.Second).Within(15 * time.Minute).WithContext(ctx).Should(BeTrue())
+
+			_, _ = fmt.Fprintln(GinkgoWriter, "Pod creation verification: completed")
+		})
+
+		It("should ensure that the dcgm-exporter pod is ready", func(ctx context.Context) {
+			_, _ = fmt.Fprintln(GinkgoWriter, "Checking pod status: started")
+			Eventually(func(ctx context.Context) bool {
+				isReady, err := kubeClient.CheckPodStatus(ctx,
+					testContext.namespace,
+					dcgmExpPod.Name,
+					func(namespace, podName string, status corev1.PodStatus) (bool, error) {
+						for _, c := range status.Conditions {
+							if c.Type != corev1.PodReady {
+								continue
+							}
+							if c.Status == corev1.ConditionTrue {
+								return true, nil
+							}
+						}
+
+						for _, c := range status.ContainerStatuses {
+							if c.State.Waiting != nil && c.State.Waiting.Reason == "CrashLoopBackOff" {
+								return false, fmt.Errorf("pod %s in namespace %s is in CrashLoopBackOff", podName, namespace)
+							}
+						}
+
+						return false, nil
+					})
+				if err != nil {
+					Fail(fmt.Sprintf("Checking pod status: Failed with error: %v", err))
+				}
+
+				return isReady
+			}).WithPolling(time.Second).Within(15 * time.Minute).WithContext(ctx).Should(BeTrue())
+			_, _ = fmt.Fprintln(GinkgoWriter, "Checking pod status: completed")
+		})
+
+		It("should create a workload pod", func(ctx context.Context) {
+			_, _ = fmt.Fprintln(GinkgoWriter, "Workload pod creation: started")
+
+			var err error
+			workloadPod, err = kubeClient.CreatePod(ctx,
+				testContext.namespace,
+				customLabels,
+				workloadPodName,
+				workloadContainerName,
+				workloadImage,
+			)
+
+			Expect(err).ShouldNot(HaveOccurred(),
+				"Workload pod creation: Failed create workload pod with err: %v", err)
+			Eventually(func(ctx context.Context) bool {
+				isReady, err := kubeClient.CheckPodStatus(ctx,
+					testContext.namespace,
+					workloadPod.Name, func(namespace, podName string, status corev1.PodStatus) (bool, error) {
+						return status.Phase == corev1.PodSucceeded, nil
+					})
+				if err != nil {
+					Fail(fmt.Sprintf("Workload pod creation: Checking pod status: Failed with error: %v", err))
+				}
+
+				return isReady
+			}).WithPolling(time.Second).Within(15 * time.Minute).WithContext(ctx).Should(BeTrue())
+
+			_, _ = fmt.Fprintln(GinkgoWriter, "Workload pod creation: completed")
+		})
+
+		It("should wait for 30 seconds, to read metrics", func() {
+			time.Sleep(30 * time.Second)
+		})
+
+		var metricsResponse []byte
+
+		It("should read metrics", func(ctx context.Context) {
+			_, _ = fmt.Fprintln(GinkgoWriter, "Read metrics: started")
+
+			Eventually(func(ctx context.Context) bool {
+				var err error
+
+				metricsResponse, err = kubeClient.DoHttpRequest(ctx,
+					testContext.namespace,
+					dcgmExpPod.Name,
+					dcgmExporterPort,
+					"metrics")
+				if err != nil {
+					Fail(fmt.Sprintf("Read metrics: Failed with error: %v", err))
+				}
+
+				return len(metricsResponse) > 0
+			}).WithPolling(time.Second).Within(time.Minute).WithContext(ctx).Should(BeTrue())
+			_, _ = fmt.Fprintln(GinkgoWriter, "Read metrics: completed")
+		})
+
+		It("should verify metrics have pod labels inside", func(ctx context.Context) {
+			Expect(metricsResponse).ShouldNot(BeEmpty())
+
+			_, _ = fmt.Fprintln(GinkgoWriter, "Read metrics: started")
+
+			// Parse and verify metrics contain custom pod labels
+			var parser expfmt.TextParser
+			metricFamilies, err := parser.TextToMetricFamilies(bytes.NewReader(metricsResponse))
+			Expect(err).ShouldNot(HaveOccurred(), "Error parsing metrics")
+			Expect(metricFamilies).ShouldNot(BeEmpty(), "No metrics found")
+
+			for _, metricFamily := range metricFamilies {
+				for _, metric := range metricFamily.GetMetric() {
+					for _, label := range metric.Label {
+						labelName := ptr.Deref(label.Name, "")
+						if slices.Contains([]string{"custom-key", "another-key"}, labelName) {
+							Expect(ptr.Deref(label.Value, "")).Should(Equal(customLabels[labelName]),
+								"Expected metric to include label %q with value %q, but got %q",
+								labelName, customLabels[labelName], ptr.Deref(label.Value, ""),
+							)
+						}
+					}
+				}
+			}
+
+			_, _ = fmt.Fprintln(GinkgoWriter, "Pod labels verified successfully in metrics")
+		})
+	})
 })

--- a/tests/e2e/internal/framework/kube.go
+++ b/tests/e2e/internal/framework/kube.go
@@ -61,6 +61,11 @@ func (c *KubeClient) CreateNamespace(
 	return c.client.CoreV1().Namespaces().Create(ctx, namespaceObj, metav1.CreateOptions{})
 }
 
+// GetNamespace checks if a namespace exists and returns its details
+func (c *KubeClient) GetNamespace(ctx context.Context, namespace string) (*corev1.Namespace, error) {
+	return c.client.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
+}
+
 // DeleteNamespace deletes the namespace
 func (c *KubeClient) DeleteNamespace(
 	ctx context.Context,


### PR DESCRIPTION
This PR adds pod label collection to DCGM Exporter metrics, allowing metrics to be associated with their corresponding Kubernetes pods. The feature can be enabled via a configurable environment variable.

## Why This Matters

This enhancement makes it easier to identify metrics at a pod level, offering deeper insights into application performance and resource usage within Kubernetes clusters.

## Backward Compatibility

The feature is opt-in and does not affect existing deployments unless explicitly configured.

## Key Changes

**1. Pod Label Collection:**

* Added support for collecting custom pod labels (custom key and another key in the tests).
* Ensured labels are included in metrics via environment variable Activation.

**2. Configurable Activation:**

* Introduced a new environment variable DCGM_EXPORTER_ENABLE_POD_LABELS to toggle pod label collection.
* The feature is disabled by default, ensuring backward compatibility.

**3. Updated Tests:**

* Validated that metrics contain the specified pod labels when the feature is enabled.
* Enhanced the test structure for clarity and maintainability, ensuring accurate validation of pod label inclusion.

## How to Enable Pod Labels

To activate the pod label collection feature, set the following environment variable in the Helm chart:

```yaml
extraEnvVars:
  - name: DCGM_EXPORTER_KUBERNETES_ENABLE_POD_LABELS
    value: "true"
```

The feature can also be activated via the command line using the `--kubernetes-enable-pod-labels` option. Note that this also requires the` --kubernetes` option to be enabled.

Refs: https://github.com/NVIDIA/dcgm-exporter/issues/423
