### PR TITLE
Sanitize pod label names

### DIFF
--- a/pkg/dcgmexporter/kubernetes.go
+++ b/pkg/dcgmexporter/kubernetes.go
@@ -249,5 +249,12 @@ func (p *PodMapper) getPodLabels(namespace, podName string) (map[string]string, 
 		return nil, err
 	}
 
-	return pod.Labels, nil
+	// Sanitize label names
+	sanitizedLabels := make((map[string]string), len(pod.Labels))
+	for k, v := range pod.Labels {
+		sanitizedKey := SanitizeLabelName(k)
+		sanitizedLabels[sanitizedKey] = v
+	}
+
+	return sanitizedLabels, nil
 }

--- a/pkg/dcgmexporter/kubernetes.go
+++ b/pkg/dcgmexporter/kubernetes.go
@@ -246,7 +246,7 @@ func (p *PodMapper) getPodLabels(namespace, podName string) (map[string]string, 
 
 	pod, err := p.Client.CoreV1().Pods(namespace).Get(ctx, podName, metav1.GetOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("failed to fetch labels: %w", err)
+		return nil, err
 	}
 
 	return pod.Labels, nil

--- a/pkg/dcgmexporter/utils.go
+++ b/pkg/dcgmexporter/utils.go
@@ -20,9 +20,12 @@ import (
 	"bytes"
 	"encoding/gob"
 	"fmt"
+	"regexp"
 	"sync"
 	"time"
 )
+
+var invalidLabelCharRE = regexp.MustCompile(`[^a-zA-Z0-9_]`)
 
 func WaitWithTimeout(wg *sync.WaitGroup, timeout time.Duration) error {
 	c := make(chan struct{})
@@ -62,4 +65,8 @@ func deepCopy[T any](src T) (dst T, err error) {
 	}
 
 	return dst, nil
+}
+
+func SanitizeLabelName(s string) string {
+	return invalidLabelCharRE.ReplaceAllString(s, "_")
 }

--- a/pkg/dcgmexporter/utils_test.go
+++ b/pkg/dcgmexporter/utils_test.go
@@ -60,3 +60,26 @@ func TestDeepCopy(t *testing.T) {
 		assert.Error(t, err)
 	})
 }
+
+func TestSanitizeLabelName(t *testing.T) {
+	t.Run("Sanitize label with invalid characters", func(t *testing.T) {
+		input := "label.with.dots/and-slashes"
+		expected := "label_with_dots_and_slashes"
+		got := SanitizeLabelName(input)
+		assert.Equal(t, expected, got)
+	})
+
+	t.Run("Sanitize label with special characters", func(t *testing.T) {
+		input := "label@with#special!chars"
+		expected := "label_with_special_chars"
+		got := SanitizeLabelName(input)
+		assert.Equal(t, expected, got)
+	})
+
+	t.Run("Keep valid label unchanged", func(t *testing.T) {
+		input := "valid_label_name"
+		expected := "valid_label_name"
+		got := SanitizeLabelName(input)
+		assert.Equal(t, expected, got)
+	})
+}


### PR DESCRIPTION
Ensure pod label names are formatted correctly by replacing invalid characters (dots, slashes, etc.) with underscores. This guarantees compatibility with Prometheus metrics without altering label values, preventing query issues and maintaining consistency in exported metrics.
