### PR TITLE
Add RBAC for Kubernetes pod labels integration

### DIFF
--- a/deployment/templates/clusterrole.yaml
+++ b/deployment/templates/clusterrole.yaml
@@ -1,0 +1,12 @@
+{{- if and .Values.kubernetes.enablePodLabels .Values.kubernetes.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "dcgm-exporter.fullname" . }}-read-pods
+  labels:
+    {{- include "dcgm-exporter.labels" . | nindent 4 }}
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list"]
+{{- end }}

--- a/deployment/templates/clusterrolebinding.yaml
+++ b/deployment/templates/clusterrolebinding.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.kubernetes.enablePodLabels .Values.kubernetes.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "dcgm-exporter.fullname" . }}-read-pods
+  labels:
+    {{- include "dcgm-exporter.labels" . | nindent 4 }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "dcgm-exporter.serviceAccountName" . }}
+  namespace: {{ include "dcgm-exporter.namespace" . }}
+roleRef:
+  kind: ClusterRole
+  name: {{ include "dcgm-exporter.fullname" . }}-read-pods
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/deployment/templates/daemonset.yaml
+++ b/deployment/templates/daemonset.yaml
@@ -112,6 +112,10 @@ spec:
         env:
         - name: "DCGM_EXPORTER_KUBERNETES"
           value: "true"
+        {{- if .Values.kubernetes.enablePodLabels }}
+        - name: "DCGM_EXPORTER_KUBERNETES_ENABLE_POD_LABELS"
+          value: "true"
+        {{- end }}
         - name: "DCGM_EXPORTER_LISTEN"
           value: "{{ .Values.service.address }}"
         - name: NODE_NAME

--- a/deployment/values.yaml
+++ b/deployment/values.yaml
@@ -194,6 +194,19 @@ basicAuth:
   #Object containing <user>:<passwords> key-value pairs for each user that will have access via basic authentication
   users: {}
 
+# Kubernetes integration settings
+kubernetes:
+  # Enable Kubernetes pod labels in metrics
+  # When enabled, metrics will include labels from the pods that are using the GPUs
+  # This requires cluster-level read permissions to pods
+  enablePodLabels: false
+
+  # RBAC settings for Kubernetes integration
+  rbac:
+    # Automatically creates ClusterRole and ClusterRoleBinding for pod access when enablePodLabels is true
+    # Set to false if you want to manage RBAC resources manually
+    create: true
+
 # Customized list of metrics to emit. Expected to be in the same format (CSV) as the default list.
 # Must be the complete list and is not additive. If unset, the default list will take effect.
 # customMetrics: |


### PR DESCRIPTION
This change adds support for conditionally creating `ClusterRole` and `ClusterRoleBinding` resources when Kubernetes pod labels are enabled in the DCGM exporter. The implementation follows the same conditional pattern used by the `serviceMonitor`, ensuring RBAC resources are only created when the pod labels feature is actually needed.

The new configuration options include `kubernetes.enablePodLabels` to control the feature and `kubernetes.rbac.create` to manage automatic RBAC resource creation. When enabled, the daemonset receives the `DCGM_EXPORTER_KUBERNETES_ENABLE_POD_LABELS` environment variable to activate pod label collection at runtime.